### PR TITLE
table-times: clean up code in Tables and UtsgParser and remove unnecessary functions

### DIFF
--- a/app/Database/CourseQueries.hs
+++ b/app/Database/CourseQueries.hs
@@ -2,7 +2,6 @@
     Module: Database.CourseQueries
     Description: Respond to various requests involving database course
                  information.
-
 This module contains the functions that perform different database queries
 and serve the information back to the client.
 -}
@@ -113,26 +112,6 @@ buildCourse fall spring year course = do
            (coursesCoreqs course)
            (coursesVideoUrls course)
 
--- buildMeeting :: Meeting -> SqlPersistM MeetingData
--- buildMeeting meeting = do
---     allMeetingTimes <- getMeetingTimes (meetingTimes meeting)
---     return $ MeetingData (meetingCode meeting)
---         (meetingSession meeting)
---         (meetingSection meeting)
---         allMeetingTimes
---         (meetingCap meeting)
---         (meetingInstructor meeting)
---         (meetingEnrol meeting)
---         (meetingWait meeting)
---         (meetingExtra meeting)
---         (meetingTimeStr meeting)
---         (meetingRoom meeting)
-
--- getMeetingTimes :: Maybe [TimeId] -> SqlPersistM (Maybe [Time])
--- getMeetingTimes Nothing = return Nothing
--- getMeetingTimes (Just keys) = do
---     maybeMeetingTimes <- map (\key -> entityVal (get key)) keys
---     return $ fmap meetingTimes maybeMeetingTimes
 
 getDescriptionB :: Maybe (Key Breadth) -> SqlPersistM (Maybe T.Text)
 getDescriptionB Nothing = return Nothing

--- a/app/Database/Tables.hs
+++ b/app/Database/Tables.hs
@@ -284,7 +284,6 @@ instance FromJSON Meeting where
     else
       fail "Not a lecture, Tutorial or Practical"
 
-
 instance FromJSON Times where
   parseJSON = withObject "Expected Object for Times" $ \o -> do
     meetingDayStr <- o .:? "meetingDay" .!= "5.0"
@@ -297,7 +296,6 @@ instance FromJSON Times where
         meetingEndTime = fromMaybe 5.0 (readMaybe meetingEndTimeStr)
     return $ Times meetingDay meetingStartTime meetingEndTime Nothing meetingRoom1 meetingRoom2
 
-
 data MeetTimes = MeetTimes { meetingData :: Meeting, timesData :: [Times] }
   deriving (Show, Generic)
 
@@ -307,7 +305,6 @@ instance FromJSON MeetTimes where
     timeMap :: HM.HashMap T.Text Times <- o .:? "schedule" .!= HM.empty <|> return HM.empty
     return $ MeetTimes meeting (HM.elems timeMap)
   parseJSON _ = fail "Invalid meeting"
-
 
 -- | Helpers for parsing JSON
 parseInstr :: Value -> Parser T.Text
@@ -327,7 +324,6 @@ parseSchedules (Object obj) = do
     let times = getTimeSlots meetingDay meetingStartTime meetingEndTime
         rooms = replicate (length times) (Room (meetingRoom1, meetingRoom2))
     return (times, rooms)
-
 parseSchedules _ = return ([], [])
 
 -- | Converts 24-hour time into a double
@@ -344,15 +340,6 @@ getDayVal "WE" = 2.0
 getDayVal "TH" = 3.0
 getDayVal "FR" = 4.0
 getDayVal _    = 4.0
-
--- | Takes a string representation of the weekday, start time and end time, and convert them to a tuple of doubles
-getTimeDbls :: Maybe String -> Maybe String -> Maybe String -> (Double, Double, Double)
-getTimeDbls (Just day) (Just start) (Just end) = do
-    let dayDbl = getDayVal day
-        startDbl = getHourVal start
-        endDbl = getHourVal end
-    (dayDbl, startDbl, endDbl)
-getTimeDbls _ _ _ = (5.0, 5.0, 5.0)
 
 -- | Takes a day and start/end times then generates a Time with the day and start/end times
 getTimeSlots :: Maybe String -> Maybe String -> Maybe String -> [Time]


### PR DESCRIPTION
Removed functions getCourseKey, getMeetingKey, parseTime and getTimeDbls. Also cleaned up function InsertMeeting to make code more concise. 